### PR TITLE
feat: add force_tick_size flag to OrderOptions for zero-API order creation

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -613,6 +613,38 @@ impl OrderBook {
         }
     }
 
+    /// Apply a price-change delta without sequence validation.
+    ///
+    /// `price_change` WS messages contain multiple entries that share the same
+    /// timestamp.  `apply_delta_fast` uses strict `sequence <= self.sequence`
+    /// ordering, which silently drops the second entry for the same token.
+    /// This method skips that check so all entries in a batch are applied.
+    ///
+    /// The caller MUST call [`set_sequence`] after the batch to advance the
+    /// book's sequence number.
+    pub fn apply_price_change_delta(
+        &mut self,
+        side: Side,
+        price: Decimal,
+        size: Decimal,
+    ) -> Result<()> {
+        let price_ticks = decimal_to_price(price)
+            .map_err(|e| PolyfillError::validation(format!("Invalid price: {e}")))?;
+        let size_units = decimal_to_qty(size)
+            .map_err(|e| PolyfillError::validation(format!("Invalid size: {e}")))?;
+        match side {
+            Side::BUY => self.apply_bid_delta_fast(price_ticks, size_units),
+            Side::SELL => self.apply_ask_delta_fast(price_ticks, size_units),
+        }
+        Ok(())
+    }
+
+    /// Set the book's sequence number after a batch of price-change deltas.
+    pub fn set_sequence(&mut self, sequence: u64) {
+        self.sequence = sequence;
+        self.trim_depth();
+    }
+
     /// Calculate the market impact for a given order size
     /// This is exactly why we don't need deep levels - if your order would require
     /// hitting prices way off the current market (like $0.95 when best ask is $0.67),
@@ -879,6 +911,39 @@ impl OrderBookManager {
             .get_mut(update.asset_id.as_str())
             .ok_or_else(|| PolyfillError::internal_simple("Failed to insert order book"))?
             .apply_book_update(update)
+    }
+
+    /// Apply a `price_change` WS message as a batch of book deltas.
+    ///
+    /// Applies all entries, then sets sequence + trims depth per affected book.
+    /// Returns the list of token_ids that were updated.
+    pub fn apply_price_change(&self, pc: &PriceChange) -> Result<Vec<String>> {
+        let mut books = self
+            .books
+            .write()
+            .map_err(|_| PolyfillError::internal_simple("Failed to acquire book lock"))?;
+
+        let mut updated: Vec<String> = Vec::new();
+
+        for entry in &pc.price_changes {
+            let Some(book) = books.get_mut(&entry.asset_id) else {
+                continue; // no book yet — skip (deltas before initial snapshot)
+            };
+            let size = entry.size.unwrap_or(Decimal::ZERO);
+            book.apply_price_change_delta(entry.side, entry.price, size)?;
+            if !updated.contains(&entry.asset_id) {
+                updated.push(entry.asset_id.clone());
+            }
+        }
+
+        // Set sequence + trim once per affected book
+        for token_id in &updated {
+            if let Some(book) = books.get_mut(token_id) {
+                book.set_sequence(pc.timestamp);
+            }
+        }
+
+        Ok(updated)
     }
 
     /// Get a book snapshot

--- a/src/book.rs
+++ b/src/book.rs
@@ -636,6 +636,12 @@ impl OrderBook {
             Side::BUY => self.apply_bid_delta_fast(price_ticks, size_units),
             Side::SELL => self.apply_ask_delta_fast(price_ticks, size_units),
         }
+        debug!(
+            "Applied price change delta: {} {} @ {} ticks",
+            side.as_str(),
+            size_units,
+            price_ticks,
+        );
         Ok(())
     }
 
@@ -942,6 +948,13 @@ impl OrderBookManager {
                 book.set_sequence(pc.timestamp);
             }
         }
+
+        debug!(
+            "Applied price_change batch: {} deltas, {} books updated (ts: {})",
+            pc.price_changes.len(),
+            updated.len(),
+            pc.timestamp,
+        );
 
         Ok(updated)
     }
@@ -1369,5 +1382,247 @@ mod tests {
 
         assert!(spread_fast.is_some()); // Should have a spread
         assert!(mid_fast.is_some()); // Should have a mid price
+    }
+
+    // --- apply_price_change_delta / apply_price_change tests ---
+
+    #[test]
+    fn price_change_delta_upserts_and_removes() {
+        let mut book = OrderBook::new("tok1".into(), 20);
+        // Seed with initial book snapshot so sequence is set
+        book.set_sequence(1);
+
+        // Upsert bid
+        book.apply_price_change_delta(Side::BUY, dec!(0.55), dec!(100))
+            .unwrap();
+        assert_eq!(book.best_bid().unwrap().price, dec!(0.55));
+        assert_eq!(book.best_bid().unwrap().size, dec!(100));
+
+        // Upsert ask
+        book.apply_price_change_delta(Side::SELL, dec!(0.60), dec!(50))
+            .unwrap();
+        assert_eq!(book.best_ask().unwrap().price, dec!(0.60));
+        assert_eq!(book.best_ask().unwrap().size, dec!(50));
+
+        // Remove bid (size = 0)
+        book.apply_price_change_delta(Side::BUY, dec!(0.55), dec!(0))
+            .unwrap();
+        assert!(book.best_bid().is_none());
+
+        // Remove ask (size = 0)
+        book.apply_price_change_delta(Side::SELL, dec!(0.60), dec!(0))
+            .unwrap();
+        assert!(book.best_ask().is_none());
+    }
+
+    #[test]
+    fn price_change_delta_skips_sequence_check() {
+        let mut book = OrderBook::new("tok1".into(), 20);
+        book.set_sequence(100);
+
+        // Both deltas apply even though sequence hasn't advanced
+        book.apply_price_change_delta(Side::BUY, dec!(0.55), dec!(100))
+            .unwrap();
+        book.apply_price_change_delta(Side::SELL, dec!(0.60), dec!(50))
+            .unwrap();
+
+        assert_eq!(book.best_bid().unwrap().price, dec!(0.55));
+        assert_eq!(book.best_ask().unwrap().price, dec!(0.60));
+        assert_eq!(book.spread().unwrap(), dec!(0.05));
+    }
+
+    #[test]
+    fn apply_delta_drops_same_sequence() {
+        // Proves the bug that apply_price_change_delta fixes
+        let mut book = OrderBook::new("tok1".into(), 20);
+
+        // First delta at seq 100 — applies
+        book.apply_delta(OrderDelta {
+            token_id: "tok1".into(),
+            timestamp: Utc::now(),
+            side: Side::BUY,
+            price: dec!(0.55),
+            size: dec!(100),
+            sequence: 100,
+        })
+        .unwrap();
+        assert_eq!(book.best_bid().unwrap().price, dec!(0.55));
+
+        // Second delta at same seq 100 — silently dropped
+        book.apply_delta(OrderDelta {
+            token_id: "tok1".into(),
+            timestamp: Utc::now(),
+            side: Side::SELL,
+            price: dec!(0.60),
+            size: dec!(50),
+            sequence: 100,
+        })
+        .unwrap();
+        assert!(
+            book.best_ask().is_none(),
+            "apply_delta should drop same-seq entry"
+        );
+    }
+
+    #[test]
+    fn set_sequence_advances_and_trims() {
+        let mut book = OrderBook::new("tok1".into(), 2); // max_depth = 2
+
+        // Add 3 bid levels
+        book.apply_price_change_delta(Side::BUY, dec!(0.50), dec!(10))
+            .unwrap();
+        book.apply_price_change_delta(Side::BUY, dec!(0.51), dec!(20))
+            .unwrap();
+        book.apply_price_change_delta(Side::BUY, dec!(0.52), dec!(30))
+            .unwrap();
+        assert_eq!(book.bids.len(), 3); // not trimmed yet
+
+        book.set_sequence(200);
+        assert_eq!(book.sequence, 200);
+        assert_eq!(book.bids.len(), 2); // trimmed to max_depth
+    }
+
+    #[test]
+    fn manager_apply_price_change_batch() {
+        let mgr = OrderBookManager::new(20);
+        // Create books for both tokens
+        mgr.get_or_create_book("yes1").unwrap();
+        mgr.get_or_create_book("no1").unwrap();
+
+        let pc = PriceChange {
+            market: "cond1".into(),
+            timestamp: 500,
+            price_changes: vec![
+                PriceChangeEntry {
+                    asset_id: "yes1".into(),
+                    side: Side::BUY,
+                    price: dec!(0.65),
+                    size: Some(dec!(100)),
+                    hash: None,
+                    best_bid: None,
+                    best_ask: None,
+                },
+                PriceChangeEntry {
+                    asset_id: "yes1".into(),
+                    side: Side::SELL,
+                    price: dec!(0.66),
+                    size: Some(dec!(80)),
+                    hash: None,
+                    best_bid: None,
+                    best_ask: None,
+                },
+                PriceChangeEntry {
+                    asset_id: "no1".into(),
+                    side: Side::BUY,
+                    price: dec!(0.34),
+                    size: Some(dec!(90)),
+                    hash: None,
+                    best_bid: None,
+                    best_ask: None,
+                },
+                PriceChangeEntry {
+                    asset_id: "no1".into(),
+                    side: Side::SELL,
+                    price: dec!(0.35),
+                    size: Some(dec!(70)),
+                    hash: None,
+                    best_bid: None,
+                    best_ask: None,
+                },
+            ],
+        };
+
+        let updated = mgr.apply_price_change(&pc).unwrap();
+        assert_eq!(updated.len(), 2);
+
+        // Both sides applied for yes1 — no crossed book
+        let yes_book = mgr.get_book("yes1").unwrap();
+        assert_eq!(yes_book.bids.first().unwrap().price, dec!(0.65));
+        assert_eq!(yes_book.asks.first().unwrap().price, dec!(0.66));
+        assert!(yes_book.asks.first().unwrap().price > yes_book.bids.first().unwrap().price);
+
+        // Both sides applied for no1 — no crossed book
+        let no_book = mgr.get_book("no1").unwrap();
+        assert_eq!(no_book.bids.first().unwrap().price, dec!(0.34));
+        assert_eq!(no_book.asks.first().unwrap().price, dec!(0.35));
+        assert!(no_book.asks.first().unwrap().price > no_book.bids.first().unwrap().price);
+    }
+
+    #[test]
+    fn manager_apply_price_change_skips_unknown_token() {
+        let mgr = OrderBookManager::new(20);
+        // Only create book for yes1, not no1
+        mgr.get_or_create_book("yes1").unwrap();
+
+        let pc = PriceChange {
+            market: "cond1".into(),
+            timestamp: 500,
+            price_changes: vec![
+                PriceChangeEntry {
+                    asset_id: "yes1".into(),
+                    side: Side::BUY,
+                    price: dec!(0.65),
+                    size: Some(dec!(100)),
+                    hash: None,
+                    best_bid: None,
+                    best_ask: None,
+                },
+                PriceChangeEntry {
+                    asset_id: "no1".into(),
+                    side: Side::BUY,
+                    price: dec!(0.34),
+                    size: Some(dec!(90)),
+                    hash: None,
+                    best_bid: None,
+                    best_ask: None,
+                },
+            ],
+        };
+
+        let updated = mgr.apply_price_change(&pc).unwrap();
+        assert_eq!(updated, vec!["yes1"]);
+    }
+
+    #[test]
+    fn manager_apply_price_change_size_zero_removes() {
+        let mgr = OrderBookManager::new(20);
+        mgr.get_or_create_book("tok1").unwrap();
+
+        // Add a level
+        let pc1 = PriceChange {
+            market: "m1".into(),
+            timestamp: 100,
+            price_changes: vec![PriceChangeEntry {
+                asset_id: "tok1".into(),
+                side: Side::BUY,
+                price: dec!(0.50),
+                size: Some(dec!(100)),
+                hash: None,
+                best_bid: None,
+                best_ask: None,
+            }],
+        };
+        mgr.apply_price_change(&pc1).unwrap();
+        assert_eq!(
+            mgr.get_book("tok1").unwrap().bids.first().unwrap().price,
+            dec!(0.50)
+        );
+
+        // Remove it with size = 0
+        let pc2 = PriceChange {
+            market: "m1".into(),
+            timestamp: 200,
+            price_changes: vec![PriceChangeEntry {
+                asset_id: "tok1".into(),
+                side: Side::BUY,
+                price: dec!(0.50),
+                size: Some(dec!(0)),
+                hash: None,
+                best_bid: None,
+                best_ask: None,
+            }],
+        };
+        mgr.apply_price_change(&pc2).unwrap();
+        assert!(mgr.get_book("tok1").unwrap().bids.is_empty());
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -847,12 +847,20 @@ impl ClobClient {
         token_id: &str,
         options: Option<&OrderOptions>,
     ) -> Result<OrderOptions> {
-        let (tick_size, neg_risk, fee_rate_bps) = match options {
-            Some(o) => (o.tick_size, o.neg_risk, o.fee_rate_bps),
-            None => (None, None, None),
+        let (tick_size, neg_risk, fee_rate_bps, force_tick_size) = match options {
+            Some(o) => (o.tick_size, o.neg_risk, o.fee_rate_bps, o.force_tick_size),
+            None => (None, None, None, false),
         };
 
-        let tick_size = self.resolve_tick_size(token_id, tick_size).await?;
+        let tick_size = if force_tick_size {
+            match tick_size {
+                Some(t) => t,
+                None => self.get_tick_size(token_id).await?,
+            }
+        } else {
+            self.resolve_tick_size(token_id, tick_size).await?
+        };
+
         let neg_risk = match neg_risk {
             Some(nr) => nr,
             None => self.get_neg_risk(token_id).await?,
@@ -862,6 +870,7 @@ impl ClobClient {
             tick_size: Some(tick_size),
             neg_risk: Some(neg_risk),
             fee_rate_bps,
+            force_tick_size: false,
         })
     }
 
@@ -3626,5 +3635,129 @@ mod tests {
         let approved = client.approve_rfq_order(&exec).await.unwrap();
         assert_eq!(approved.trade_ids, vec!["t1".to_string(), "t2".to_string()]);
         approve_mock.assert_async().await;
+    }
+
+    // --- force_tick_size tests ---
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_force_tick_size_skips_api_call() {
+        use crate::types::OrderOptions;
+
+        let mut server = Server::new_async().await;
+
+        // Mock tick-size endpoint — should NOT be called
+        let tick_mock = server
+            .mock("GET", "/tick-size")
+            .expect(0)
+            .create_async()
+            .await;
+
+        // Mock neg-risk endpoint — should NOT be called
+        let neg_risk_mock = server
+            .mock("GET", "/neg-risk")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let client = create_test_client(&server.url());
+        let options = OrderOptions {
+            tick_size: Some(Decimal::from_str("0.01").unwrap()),
+            neg_risk: Some(false),
+            fee_rate_bps: Some(100),
+            force_tick_size: true,
+        };
+
+        let filled = client
+            .get_filled_order_options("0x123", Some(&options))
+            .await
+            .unwrap();
+
+        // Verify returned values match input — no API calls made
+        assert_eq!(filled.tick_size, Some(Decimal::from_str("0.01").unwrap()));
+        assert_eq!(filled.neg_risk, Some(false));
+        assert_eq!(filled.fee_rate_bps, Some(100));
+
+        tick_mock.assert_async().await;
+        neg_risk_mock.assert_async().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_force_tick_size_false_still_validates() {
+        use crate::types::OrderOptions;
+
+        let mut server = Server::new_async().await;
+
+        // With force_tick_size=false, the API IS called for validation
+        let tick_mock = server
+            .mock("GET", "/tick-size")
+            .match_query(Matcher::UrlEncoded("token_id".into(), "0x123".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"minimum_tick_size": "0.001"}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = create_test_client(&server.url());
+        let options = OrderOptions {
+            tick_size: Some(Decimal::from_str("0.01").unwrap()),
+            neg_risk: Some(false),
+            fee_rate_bps: None,
+            force_tick_size: false,
+        };
+
+        let filled = client
+            .get_filled_order_options("0x123", Some(&options))
+            .await
+            .unwrap();
+
+        assert_eq!(filled.tick_size, Some(Decimal::from_str("0.01").unwrap()));
+        tick_mock.assert_async().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_force_tick_size_true_but_none_falls_back_to_api() {
+        use crate::types::OrderOptions;
+
+        let mut server = Server::new_async().await;
+
+        // force_tick_size=true but tick_size=None → must fetch from API
+        let tick_mock = server
+            .mock("GET", "/tick-size")
+            .match_query(Matcher::UrlEncoded("token_id".into(), "0x123".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"minimum_tick_size": "0.01"}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let neg_risk_mock = server
+            .mock("GET", "/neg-risk")
+            .match_query(Matcher::UrlEncoded("token_id".into(), "0x123".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"neg_risk": true}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = create_test_client(&server.url());
+        let options = OrderOptions {
+            tick_size: None,
+            neg_risk: None,
+            fee_rate_bps: None,
+            force_tick_size: true,
+        };
+
+        let filled = client
+            .get_filled_order_options("0x123", Some(&options))
+            .await
+            .unwrap();
+
+        assert_eq!(filled.tick_size, Some(Decimal::from_str("0.01").unwrap()));
+        assert_eq!(filled.neg_risk, Some(true));
+        tick_mock.assert_async().await;
+        neg_risk_mock.assert_async().await;
     }
 }

--- a/src/orders.rs
+++ b/src/orders.rs
@@ -512,6 +512,7 @@ mod tests {
                     tick_size: Some(Decimal::from_str("0.01").unwrap()),
                     neg_risk: Some(false),
                     fee_rate_bps: None,
+                    force_tick_size: false,
                 },
             )
             .unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -547,6 +547,9 @@ pub struct OrderOptions {
     pub tick_size: Option<Decimal>,
     pub neg_risk: Option<bool>,
     pub fee_rate_bps: Option<u32>,
+    /// When true and tick_size is Some, skip the API validation call entirely.
+    /// Use when tick_size was pre-fetched via `get_tick_size` and is known-valid.
+    pub force_tick_size: bool,
 }
 
 /// Extra arguments for order creation


### PR DESCRIPTION
- Add force_tick_size field to OrderOptions — when true with tick_size: Some, skips resolve_tick_size API call in get_filled_order_options
- Enables callers who pre-cache tick_size to eliminate all API calls from order creation hot path
- 3 new tests covering skip/validate/fallback behavior