### PR TITLE
chore(release): 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "polyfill-rs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyfill-rs"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Julius Tranquilli <jtranqs@gmail.com>"]
 description = "The Fastest Polymarket Client On The Market."


### PR DESCRIPTION
## Summary
- Bump crate version to 0.4.1
- Prepare patch release for websocket book snapshot handling and hickory resolver audit fix

## Verification
- `cargo test --lib`
- `cargo test --test no_alloc_hot_paths`
- `cargo audit`
- `cargo publish --dry-run`