### PR TITLE
test: benchmark real order and book hot paths

### DIFF
--- a/benches/comparison_benchmarks.rs
+++ b/benches/comparison_benchmarks.rs
@@ -1,22 +1,125 @@
+use alloy_signer_local::PrivateKeySigner;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use polyfill_rs::{OrderArgs, OrderBookImpl, Side};
+use polyfill_rs::{
+    auth::create_l2_headers,
+    orders::{OrderBuilder, BYTES32_ZERO},
+    types::{
+        ApiCredentials, CreateOrderOptions, FastOrderDelta, OrderDelta, OrderType, PostOrder,
+        PostOrderOptions,
+    },
+    OrderArgs, OrderBookImpl, Side,
+};
 use rust_decimal::Decimal;
 use std::str::FromStr;
 
-// Benchmark: Create an order with EIP-712 signature (computational cost only)
+const TOKEN_ID: &str = "12345678901234567890";
+const CHAIN_ID: u64 = 137;
+const PRIVATE_KEY: &str = "0x1234567890123456789012345678901234567890123456789012345678901234";
+
+fn test_signer() -> PrivateKeySigner {
+    PRIVATE_KEY.parse().expect("valid benchmark private key")
+}
+
+fn test_order_args() -> OrderArgs {
+    OrderArgs {
+        token_id: TOKEN_ID.to_string(),
+        price: Decimal::from_str("0.7537").unwrap(),
+        size: Decimal::from_str("100.25").unwrap(),
+        side: Side::BUY,
+        expiration: Some(1_900_000_000),
+        builder_code: Some(BYTES32_ZERO.to_string()),
+        metadata: Some(BYTES32_ZERO.to_string()),
+    }
+}
+
+fn test_order_options() -> CreateOrderOptions {
+    CreateOrderOptions {
+        tick_size: Some(Decimal::from_str("0.0001").unwrap()),
+        neg_risk: Some(false),
+    }
+}
+
+fn token_hash(token_id: &str) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    token_id.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn fast_delta(token_id_hash: u64) -> FastOrderDelta {
+    FastOrderDelta {
+        token_id_hash,
+        timestamp: chrono::Utc::now(),
+        side: Side::BUY,
+        price: 7_537,
+        size: 1_002_500,
+        sequence: 0,
+    }
+}
+
+fn decimal_delta() -> OrderDelta {
+    OrderDelta {
+        token_id: TOKEN_ID.to_string(),
+        timestamp: chrono::Utc::now(),
+        side: Side::BUY,
+        price: Decimal::from_str("0.7537").unwrap(),
+        size: Decimal::from_str("100.25").unwrap(),
+        sequence: 0,
+    }
+}
+
+// Benchmark: Create and EIP-712 sign a limit order.
 fn benchmark_create_order_eip712(c: &mut Criterion) {
+    let signer = test_signer();
+    let builder = OrderBuilder::new(signer, None, None);
+    let order_args = test_order_args();
+    let options = test_order_options();
+
     c.bench_function("create_order_eip712_signature", |b| {
         b.iter(|| {
-            // Create order arguments - this benchmarks the computational cost
-            let order_args = OrderArgs::new(
-                "test_token_id",
-                Decimal::from_str("0.75").unwrap(),
-                Decimal::from_str("100.0").unwrap(),
-                Side::BUY,
-            );
+            let signed_order = builder
+                .create_order(
+                    black_box(CHAIN_ID),
+                    black_box(&order_args),
+                    black_box(&options),
+                )
+                .unwrap();
+            black_box(signed_order)
+        })
+    });
+}
 
-            // Simulate the computational work of order creation
-            black_box(order_args)
+// Benchmark: Serialize a signed order body and build L2 auth headers for POST /order.
+fn benchmark_order_submit_payload_auth(c: &mut Criterion) {
+    let signer = test_signer();
+    let builder = OrderBuilder::new(signer.clone(), None, None);
+    let signed_order = builder
+        .create_order(CHAIN_ID, &test_order_args(), &test_order_options())
+        .unwrap();
+    let post_options = PostOrderOptions {
+        order_type: OrderType::GTD,
+        post_only: false,
+        defer_exec: false,
+    };
+    let api_creds = ApiCredentials {
+        api_key: "benchmark-api-key".to_string(),
+        secret: "dGVzdF9zZWNyZXRfa2V5XzEyMzQ1".to_string(),
+        passphrase: "benchmark-passphrase".to_string(),
+    };
+
+    c.bench_function("order_submit_body_and_l2_headers", |b| {
+        b.iter(|| {
+            let body = PostOrder::new(
+                black_box(signed_order.clone()),
+                black_box(api_creds.api_key.clone()),
+                black_box(post_options),
+            );
+            let body_bytes = serde_json::to_vec(black_box(&body)).unwrap();
+            let headers =
+                create_l2_headers(&signer, &api_creds, "POST", "/order", Some(&body)).unwrap();
+            black_box((body_bytes, headers))
         })
     });
 }
@@ -34,30 +137,37 @@ fn benchmark_json_parsing(c: &mut Criterion) {
     });
 }
 
-// Benchmark: Order book operations
-fn benchmark_order_book_operations(c: &mut Criterion) {
-    c.bench_function("order_book_updates", |b| {
+// Benchmark: Core fixed-point order book update path.
+fn benchmark_order_book_core_operations(c: &mut Criterion) {
+    let token_id_hash = token_hash(TOKEN_ID);
+    let mut book = OrderBookImpl::new(TOKEN_ID.to_string(), 100);
+    let delta_template = fast_delta(token_id_hash);
+    let mut sequence = 0;
+
+    c.bench_function("order_book_apply_delta_fast_core", |b| {
         b.iter(|| {
-            let mut book = OrderBookImpl::new("test_token".to_string(), 100);
+            sequence += 1;
+            let mut delta = delta_template;
+            delta.sequence = sequence;
+            book.apply_delta_fast(black_box(delta)).unwrap();
+            black_box(book.sequence)
+        })
+    });
+}
 
-            // Simulate rapid order book updates
-            for i in 0..1000 {
-                let price = Decimal::from_str(&format!("0.{:04}", 5000 + (i % 100))).unwrap();
-                let size = Decimal::from_str("100.0").unwrap();
+// Benchmark: External Decimal OrderDelta ingestion through the ergonomic API.
+fn benchmark_order_book_external_ingestion(c: &mut Criterion) {
+    let mut book = OrderBookImpl::new(TOKEN_ID.to_string(), 100);
+    let delta_template = decimal_delta();
+    let mut sequence = 0;
 
-                let bid_delta = polyfill_rs::OrderDelta {
-                    token_id: "test_token".to_string(),
-                    timestamp: chrono::Utc::now(),
-                    side: polyfill_rs::Side::BUY,
-                    price,
-                    size,
-                    sequence: i as u64,
-                };
-
-                let _ = book.apply_delta(bid_delta);
-            }
-
-            black_box(book)
+    c.bench_function("order_book_external_decimal_ingestion", |b| {
+        b.iter(|| {
+            sequence += 1;
+            let mut delta = delta_template.clone();
+            delta.sequence = sequence;
+            book.apply_delta(black_box(delta)).unwrap();
+            black_box(book.sequence)
         })
     });
 }
@@ -100,8 +210,10 @@ fn benchmark_fast_operations(c: &mut Criterion) {
 criterion_group!(
     benches,
     benchmark_create_order_eip712,
+    benchmark_order_submit_payload_auth,
     benchmark_json_parsing,
-    benchmark_order_book_operations,
+    benchmark_order_book_core_operations,
+    benchmark_order_book_external_ingestion,
     benchmark_fast_operations
 );
 criterion_main!(benches);


### PR DESCRIPTION
## Summary
- make the EIP-712 order benchmark call the real OrderBuilder::create_order signing path
- add a separate submit-body/L2-auth benchmark for POST /order payload work
- split order book benchmarks into fixed-point core updates and external Decimal ingestion

## Verification
- cargo fmt --check
- cargo check --benches
- cargo bench --bench comparison_benchmarks

## Latest local benchmark results
| Benchmark | Result |
|---|---:|
| create_order_eip712_signature | 36.126-37.816 us |
| order_submit_body_and_l2_headers | 3.068-3.093 us |
| json_parsing_markets | 1.405-1.416 us |
| order_book_apply_delta_fast_core | 6.450-6.515 ns |
| order_book_external_decimal_ingestion | 36.939-36.964 ns |
| fast_spread_mid_calculations | 3.605-3.622 ns |