### PR TITLE
docs: refresh benchmark comparison results

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Real-world Polymarket API latency broken down by request phase:
 | Operation | Metric | polyfill-rs | rs-clob-client-v2 | polymarket-rs-client | Official Python Client |
 |-----------|--------|-------------|-------------------|----------------------|------------------------|
 | **Fetch Markets** | mean ± sd | **321.6 ms ± 92.9 ms** | - | 409.3 ms ± 137.6 ms | 1.366 s ± 0.048 s |
-| **Cold Start** | single run | 651.7 ms | **543.9 ms** | - | - |
-| **Warm Connection** | single run | **202.9 ms** | 497.2 ms | - | - |
-| **Steady Typed Total** | p50 / p95 / p99 | **209.9 / 276.1 / 509.5 ms** | 215.9 / 284.7 / 312.4 ms | - | - |
-| **Network-Only Byte Fetch** | p50 / p95 / p99 | 382.5 / 590.3 / 626.7 ms | **300.1 / 449.0 / 520.1 ms** | - | - |
-| **CPU Parse Only** | p50 / p95 / p99 | **0.5 / 1.2 / 1.4 ms** | 1.3 / 1.4 / 1.4 ms | - | - |
+| **Cold Start** | single run | 759.3 ms | **568.0 ms** | - | - |
+| **Warm Connection** | single run | **153.0 ms** | 191.9 ms | - | - |
+| **Steady Typed Total** | p50 / p95 / p99 | **228.2 / 509.9 / 611.2 ms** | 242.3 / 514.2 / 641.3 ms | - | - |
+| **Network-Only Byte Fetch** | p50 / p95 / p99 | 200.0 / **327.3 / 518.6 ms** | **123.3** / 456.9 / 867.2 ms | - | - |
+| **CPU Parse Only** | p50 / p95 / p99 | **0.5 / 1.1 / 1.3 ms** | 1.3 / 1.6 / 1.7 ms | - | - |
 
 
 **Performance vs polymarket-rs-client:**
@@ -62,7 +62,7 @@ Real-world Polymarket API latency broken down by request phase:
 - **32.5% more consistent** 
 - **4.2x faster** than Official Python Client
 
-**Benchmark Methodology:** The `rs-clob-client-v2` comparison separates cold start, warm connection, steady-state typed requests, network-only byte fetches, and CPU-only parsing. Steady-state rows use 20 paired iterations with alternating order and 100ms delay; parse rows use 200 iterations from a cached 480KB payload. The network-only row compares byte fetches through each HTTP stack without typed deserialization. Run it with `cargo run --release --example official_client_side_by_side_benchmark --features official-client-benchmark`. See `examples/side_by_side_benchmark.rs` in commit `a63a170`: https://github.com/floor-licker/polyfill-rs/blob/a63a170/examples/side_by_side_benchmark.rs for the original legacy benchmark implementation.
+**Benchmark Methodology:** The `rs-clob-client-v2` comparison separates cold start, warm connection, steady-state typed requests, network-only byte fetches, and CPU-only parsing. The latest local live-network run was on June 22, 2026 against `https://clob.polymarket.com/simplified-markets?next_cursor=MA==`. Steady-state rows use 40 paired iterations with alternating order and 100ms delay after 5 warmups; parse rows use 300 iterations from a cached 480KB payload. The network-only row compares byte fetches through each HTTP stack without typed deserialization. The CPU parse row compares polyfill typed parsing against the `rs-clob-client-v2` request-helper parse path; direct serde parsing of the SDK response type measured 0.5 / 0.6 / 0.6 ms. Run it with `cargo run --release --example official_client_side_by_side_benchmark --features official-client-benchmark`. See `examples/side_by_side_benchmark.rs` in commit `a63a170`: https://github.com/floor-licker/polyfill-rs/blob/a63a170/examples/side_by_side_benchmark.rs for the original legacy benchmark implementation.
 
 **Computational Performance (pure CPU, no I/O)**
 

--- a/assets/benchmark-results.svg
+++ b/assets/benchmark-results.svg
@@ -15,21 +15,21 @@
 
   <text class="group" x="40" y="38">Steady typed total, p50</text>
   <text class="label" x="40" y="68">polyfill-rs</text>
-  <rect class="polyfill" x="210" y="54" width="584" height="18" rx="3"/>
-  <text class="value" x="812" y="68">209.9 ms</text>
+  <rect class="polyfill" x="210" y="54" width="565" height="18" rx="3"/>
+  <text class="value" x="793" y="68">228.2 ms</text>
   <text class="label" x="40" y="96">rs-clob-client-v2</text>
   <rect class="compare" x="210" y="82" width="600" height="18" rx="3"/>
-  <text class="value" x="828" y="96">215.9 ms</text>
+  <text class="value" x="828" y="96">242.3 ms</text>
 
   <line class="rule" x1="40" y1="128" x2="940" y2="128"/>
 
   <text class="group" x="40" y="158">Network-only byte fetch, p50</text>
   <text class="label" x="40" y="188">polyfill-rs</text>
   <rect class="polyfill" x="210" y="174" width="600" height="18" rx="3"/>
-  <text class="value" x="828" y="188">382.5 ms</text>
+  <text class="value" x="828" y="188">200.0 ms</text>
   <text class="label" x="40" y="216">rs-clob-client-v2</text>
-  <rect class="compare" x="210" y="202" width="471" height="18" rx="3"/>
-  <text class="value" x="699" y="216">300.1 ms</text>
+  <rect class="compare" x="210" y="202" width="370" height="18" rx="3"/>
+  <text class="value" x="598" y="216">123.3 ms</text>
 
   <line class="rule" x1="40" y1="248" x2="940" y2="248"/>
 


### PR DESCRIPTION
## Summary
- refresh README benchmark rows for the rs-clob-client-v2 comparison
- refresh assets/benchmark-results.svg from the same p50 values
- update benchmark methodology to describe the longer run

## Benchmark Run
Command:
POLYMARKET_BENCH_ITERATIONS=40 POLYMARKET_BENCH_WARMUPS=5 POLYMARKET_BENCH_PARSE_ITERATIONS=300 POLYMARKET_BENCH_DELAY_MS=100 cargo run --release --example official_client_side_by_side_benchmark --features official-client-benchmark

Results:
- Cold start: polyfill-rs 759.3 ms vs rs-clob-client-v2 568.0 ms
- Warm connection: polyfill-rs 153.0 ms vs rs-clob-client-v2 191.9 ms
- Steady typed p50/p95/p99: polyfill-rs 228.2 / 509.9 / 611.2 ms vs rs-clob-client-v2 242.3 / 514.2 / 641.3 ms
- Network-only p50/p95/p99: polyfill-rs 200.0 / 327.3 / 518.6 ms vs rs-clob-client-v2-style HTTP 123.3 / 456.9 / 867.2 ms
- CPU parse p50/p95/p99: polyfill-rs 0.5 / 1.1 / 1.3 ms vs rs-clob-client-v2 request-helper parse 1.3 / 1.6 / 1.7 ms

## Verification
- cargo fmt --all -- --check
- git diff --check