### PR TITLE
docs: remove unsupported buffer pool claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The 21.4% performance improvement comes from SIMD-accelerated JSON parsing (1.77
 
 ### Memory Architecture
 
-Pre-allocated pools eliminate allocation latency spikes. Configurable book depth limiting prevents memory bloat. Hot data structures group frequently-accessed fields for cache line efficiency.
+Configurable book depth limiting prevents memory bloat. Hot data structures group frequently-accessed fields for cache line efficiency. Allocation-sensitive hot paths are covered by targeted no-allocation tests where the implementation is currently allocation-free.
 
 ### Architectural Principles
 


### PR DESCRIPTION
## Summary
- remove the README claim that pre-allocated pools eliminate allocation latency spikes
- replace it with wording that matches current implementation: depth limiting, cache-conscious hot data, and no-allocation tests for paths that are actually allocation-free

## Verification
- `git diff --check`
- README-only change