### PR TITLE
chore: release 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3220,7 +3220,7 @@ dependencies = [
 
 [[package]]
 name = "polyfill-rs"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyfill-rs"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Julius Tranquilli <jtranqs@gmail.com>"]
 description = "The Fastest Polymarket Client On The Market."
@@ -65,7 +65,7 @@ parking_lot = "0.12"
 tokio-tungstenite = { version = "0.21", optional = true, features = ["native-tls"] }
 
 # Optional benchmark-only dependency for comparing against Polymarket's active Rust SDK.
-polymarket_client_sdk_v2 = { git = "https://github.com/Polymarket/rs-clob-client-v2", rev = "8ba5008733c3c03e92041eef8b1cb8495dbed718", features = ["clob"], optional = true }
+polymarket_client_sdk_v2 = { version = "0.6.0-canary.1", git = "https://github.com/Polymarket/rs-clob-client-v2", rev = "8ba5008733c3c03e92041eef8b1cb8495dbed718", features = ["clob"], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }


### PR DESCRIPTION
## Summary
- bump polyfill-rs to 0.4.2 for the POLY_1271 deposit-wallet signing fix
- add a crates.io version requirement for the optional benchmark dependency so publishing succeeds

## Verification
- cargo fmt -- --check
- cargo check --quiet
- cargo check --all-features --quiet
- cargo test --quiet
- cargo publish --dry-run